### PR TITLE
Update fessa.py

### DIFF
--- a/fessa.py
+++ b/fessa.py
@@ -1,44 +1,32 @@
 ###################################################################
 # Fessa palette for python matplotlib
 ###################################################################
-import matplotlib
-import matplotlib.pyplot as plt
-from matplotlib.colors import LinearSegmentedColormap
-
-def hex_to_rgb(value):
-    value = value.lstrip('#')
-    lv = len(value)
-    rgb=tuple(int(value[i:i + lv // 3], 16) for i in range(0, lv, lv // 3))
-    return tuple([x/255. for x in rgb])
-
+from matplotlib.colors import LinearSegmentedColormap, ColorConverter
+from matplotlib.cm import register_cmap
 
 paletteFessa = [
-          hex_to_rgb("#1F3B73"),
-          hex_to_rgb("#2F9294"),
-          hex_to_rgb("#50B28D"),
-          hex_to_rgb("#A7D655"),
-          hex_to_rgb("#FFE03E"),
-          hex_to_rgb("#FFA955"),
-          hex_to_rgb("#D6573B")
-         ]
+    '#1F3B73', # dark-blue
+    '#2F9294', # green-blue
+    '#50B28D', # green
+    '#A7D655', # pisello
+    '#FFE03E', # yellow
+    '#FFA955', # orange
+    '#D6573B', # red
+]
 
-cm_fessa = LinearSegmentedColormap.from_list("fessa", paletteFessa, N=1000)
+cm_fessa = LinearSegmentedColormap.from_list('fessa', paletteFessa)
+register_cmap(cmap=cm_fessa)
+register_cmap(cmap=cm_fessa.reversed())
 
-matplotlib.colors.ColorConverter.colors['fessa1'] = paletteFessa[0]
-matplotlib.colors.ColorConverter.colors['fessa2'] = paletteFessa[1]
-matplotlib.colors.ColorConverter.colors['fessa3'] = paletteFessa[2]
-matplotlib.colors.ColorConverter.colors['fessa4'] = paletteFessa[3]
-matplotlib.colors.ColorConverter.colors['fessa5'] = paletteFessa[4]
-matplotlib.colors.ColorConverter.colors['fessa6'] = paletteFessa[5]
-matplotlib.colors.ColorConverter.colors['fessa7'] = paletteFessa[6]
+for i in range(len(paletteFessa)):
+    ColorConverter.colors[f'fessa{i}'] = paletteFessa[i]
 
-fessaNames=['fessa1', 'fessa2' , 'fessa3', 'fessa4', 
-              'fessa5', 'fessa6' , 'fessa7']
-
-# Usage examples
-# For contour plots
-# plt.contourf(X,Y,Z,cmap=cm_fessa)
-# For standard plots
-# plt.plot(x,y,color=paletteFessa[0])
-# or
-# plt.plot(x,y,color='fessa1')
+### To set it as default
+# import fessa
+# plt.set_cmap('fessa')
+### or the reversed one
+# plt.set_cmap('fessa_r')
+### For contour plots
+# plt.contourf(X, Y, Z, cmap='fessa')
+### For standard plots
+# plt.plot(x, y, color='fessa0')


### PR DESCRIPTION
- registering the palette, for easier usage
- simplifying the code
- back compatible, except that colors now start from 'fessa0' instead of 'fessa1' (I like it better this way, but you can try to convince me otherwise)